### PR TITLE
fix: restore CI and acceptance stability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release
 on:
   workflow_dispatch:
 
+env:
+  # Must match go.mod / toolchain.
+  GO_VERSION: '1.24.1'
+
 permissions:
   contents: write
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ permissions:
 # Default values to simplify job configurations below.
 env:
   # Go language version to use for building. This value should also be updated
-  # in the release workflow if changed.
-  GO_VERSION: '1.19'
+  # in the release workflow if changed. Must match go.mod / toolchain.
+  GO_VERSION: '1.24.1'
 
 jobs:
   # Ensure project builds before running testing matrix

--- a/internal/provider/environment_resource_test.go
+++ b/internal/provider/environment_resource_test.go
@@ -7,30 +7,32 @@ import (
 )
 
 func TestAccEnvironmentResource(t *testing.T) {
+	testAccPreCheck(t)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 nil,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				Config: testAccEnvironmentResourceConfig,
+				Config: testAccEnvironmentResourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("devcycle_environment.test", "project_id", "622112634cabe0e9fbaf974d"),
 				),
 			},
 			{
-				Config:  testAccEnvironmentResourceConfig,
+				Config:  testAccEnvironmentResourceConfig(),
 				Destroy: true,
 			},
 		},
 	})
 }
 
-var testAccEnvironmentResourceConfig = `
+func testAccEnvironmentResourceConfig() string {
+	return `
 resource "devcycle_environment" "test" {
   project_id = "622112634cabe0e9fbaf974d"
-  name = "TerraformAccTest` + randSeq(5) + `"
-  key = "terraform-acceptance-testing` + randSeq(5) + `"
+  name = "TerraformAccTest` + randString + `"
+  key = "terraform-acceptance-testing` + randString + `"
   description = "Terraform acceptance testing"
   color = "#232323"
   type = "development"
@@ -39,3 +41,4 @@ resource "devcycle_environment" "test" {
   }
 }
 `
+}

--- a/internal/provider/feature_resource.go
+++ b/internal/provider/feature_resource.go
@@ -474,12 +474,8 @@ func (r featureResource) Delete(ctx context.Context, req tfsdk.DeleteResourceReq
 		return
 	}
 
-	for _, variable := range data.Variables {
-		httpResponse, err := r.provider.MgmtClient.VariablesApi.VariablesControllerRemove(ctx, variable.Id.Value, data.ProjectId.Value)
-		if ret := handleDevCycleHTTP(err, httpResponse, &resp.Diagnostics); ret {
-			return
-		}
-	}
+	// Delete the feature only; child variables are removed by the API. Deleting
+	// variables by ID first returned 412 Precondition Failed against the live API.
 	httpResponse, err := r.provider.MgmtClient.FeaturesApi.FeaturesControllerRemove(ctx, data.Key.Value, data.ProjectId.Value)
 	if ret := handleDevCycleHTTP(err, httpResponse, &resp.Diagnostics); ret {
 		return

--- a/internal/provider/feature_resource.go
+++ b/internal/provider/feature_resource.go
@@ -474,10 +474,8 @@ func (r featureResource) Delete(ctx context.Context, req tfsdk.DeleteResourceReq
 		return
 	}
 
-	// Delete the feature only; child variables are removed by the API. Deleting
-	// variables by ID first returned 412 Precondition Failed against the live API.
-	httpResponse, err := r.provider.MgmtClient.FeaturesApi.FeaturesControllerRemove(ctx, data.Key.Value, data.ProjectId.Value)
-	if ret := handleDevCycleHTTP(err, httpResponse, &resp.Diagnostics); ret {
+	// Ask the API to delete associated variables along with the feature.
+	if ret := r.provider.featureControllerDelete(ctx, data.Key.Value, data.ProjectId.Value, &resp.Diagnostics); ret {
 		return
 	}
 

--- a/internal/provider/feature_resource_test.go
+++ b/internal/provider/feature_resource_test.go
@@ -7,33 +7,35 @@ import (
 )
 
 func TestAccFeatureResource(t *testing.T) {
+	testAccPreCheck(t)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 nil,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				Config: testAccFeatureResourceConfig,
+				Config: testAccFeatureResourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("devcycle_feature.test", "project_id", "622112634cabe0e9fbaf974d"),
 				),
 			},
 			{
-				Config: testAccFeatureResourceConfigEdit,
+				Config: testAccFeatureResourceConfigEdit(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("devcycle_feature.test", "project_id", "622112634cabe0e9fbaf974d"),
 					resource.TestCheckResourceAttr("devcycle_feature.test", "description", "Terraform acceptance testing edited"),
 				),
 			},
 			{
-				Config:  testAccFeatureResourceConfig,
+				Config:  testAccFeatureResourceConfig(),
 				Destroy: true,
 			},
 		},
 	})
 }
 
-var testAccFeatureResourceConfig = `
+func testAccFeatureResourceConfig() string {
+	return `
 resource "devcycle_feature" "test" {
   project_id = "622112634cabe0e9fbaf974d"
   name = "TerraformAccTest` + randString + `"
@@ -64,8 +66,10 @@ output "testing" {
   value = devcycle_feature.test.variables
 }
 `
+}
 
-var testAccFeatureResourceConfigEdit = `
+func testAccFeatureResourceConfigEdit() string {
+	return `
 resource "devcycle_feature" "test" {
   project_id = "622112634cabe0e9fbaf974d"
   name = "TerraformAccTest` + randString + `"
@@ -103,3 +107,4 @@ output "testing" {
   value = devcycle_feature.test.variables
 }
 `
+}

--- a/internal/provider/mgmt_http.go
+++ b/internal/provider/mgmt_http.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -36,7 +37,7 @@ func (t retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		cloned.Header = req.Header.Clone()
 
 		resp, err = base.RoundTrip(cloned)
-		if !shouldRetryMgmtRequest(req.Method, resp, err) || attempt == 2 {
+		if !shouldRetryMgmtRequest(req, resp, err) || attempt == 2 {
 			return resp, err
 		}
 
@@ -45,20 +46,29 @@ func (t retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			_ = resp.Body.Close()
 		}
 
-		time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
+		if err := sleepWithContext(req.Context(), time.Duration(attempt+1)*500*time.Millisecond); err != nil {
+			return nil, err
+		}
 	}
 
 	return resp, err
 }
 
-func shouldRetryMgmtRequest(method string, resp *http.Response, err error) bool {
-	switch method {
+func shouldRetryMgmtRequest(req *http.Request, resp *http.Response, err error) bool {
+	switch req.Method {
 	case http.MethodGet, http.MethodDelete, http.MethodHead:
 	default:
 		return false
 	}
 
+	if req.Context().Err() != nil {
+		return false
+	}
+
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return false
+		}
 		return true
 	}
 
@@ -67,17 +77,33 @@ func shouldRetryMgmtRequest(method string, resp *http.Response, err error) bool 
 	}
 
 	switch resp.StatusCode {
-	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
 		return true
 	default:
 		return false
 	}
 }
 
+func sleepWithContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 func (p *provider) setMgmtRequestHeaders(req *http.Request) {
 	req.Header.Set("Authorization", p.AccessToken)
 	req.Header.Set("dvc-referrer", "terraform")
-	metadata := fmt.Sprintf(`{"dvc_terraform_provider_version": %q, "terraform_version": %q}`, p.version, "unknown")
+	terraformVersion := p.TerraformVersion
+	if terraformVersion == "" {
+		terraformVersion = "unknown"
+	}
+	metadata := fmt.Sprintf(`{"dvc_terraform_provider_version": %q, "terraform_version": %q}`, p.version, terraformVersion)
 	req.Header.Set("dvc-referrer-metadata", metadata)
 	req.Header.Set("User-Agent", "terraform-provider-devcycle")
 }

--- a/internal/provider/mgmt_http.go
+++ b/internal/provider/mgmt_http.go
@@ -1,0 +1,110 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const mgmtAPIBaseURL = "https://api.devcycle.com"
+
+type retryTransport struct {
+	base http.RoundTripper
+}
+
+func newMgmtHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: retryTransport{base: http.DefaultTransport},
+		Timeout:   30 * time.Second,
+	}
+}
+
+func (t retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; attempt < 3; attempt++ {
+		cloned := req.Clone(req.Context())
+		cloned.Header = req.Header.Clone()
+
+		resp, err = base.RoundTrip(cloned)
+		if !shouldRetryMgmtRequest(req.Method, resp, err) || attempt == 2 {
+			return resp, err
+		}
+
+		if resp != nil && resp.Body != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+
+		time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
+	}
+
+	return resp, err
+}
+
+func shouldRetryMgmtRequest(method string, resp *http.Response, err error) bool {
+	switch method {
+	case http.MethodGet, http.MethodDelete, http.MethodHead:
+	default:
+		return false
+	}
+
+	if err != nil {
+		return true
+	}
+
+	if resp == nil {
+		return true
+	}
+
+	switch resp.StatusCode {
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *provider) setMgmtRequestHeaders(req *http.Request) {
+	req.Header.Set("Authorization", p.AccessToken)
+	req.Header.Set("dvc-referrer", "terraform")
+	metadata := fmt.Sprintf(`{"dvc_terraform_provider_version": %q, "terraform_version": %q}`, p.version, "unknown")
+	req.Header.Set("dvc-referrer-metadata", metadata)
+	req.Header.Set("User-Agent", "terraform-provider-devcycle")
+}
+
+func (p *provider) doMgmtRequest(ctx context.Context, method, path string, query url.Values, headers map[string]string) (*http.Response, error) {
+	u, err := url.Parse(mgmtAPIBaseURL + path)
+	if err != nil {
+		return nil, err
+	}
+	if len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	p.setMgmtRequestHeaders(req)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	client := p.MgmtHTTPClient
+	if client == nil {
+		client = newMgmtHTTPClient()
+	}
+
+	return client.Do(req)
+}

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -7,46 +7,53 @@ import (
 )
 
 func TestAccProjectResource(t *testing.T) {
+	testAccPreCheck(t)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 nil,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				Config: testAccProjectResourceConfig,
+				Config: testAccProjectResourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("devcycle_project.test", "key", testAccProjectResourceKey),
+					resource.TestCheckResourceAttr("devcycle_project.test", "key", testAccProjectResourceKey()),
 					resource.TestCheckResourceAttr("devcycle_project.test", "description", "Terraform acceptance testing"),
 				),
 			},
 			{
-				Config: testAccProjectResourceConfigEdit,
+				Config: testAccProjectResourceConfigEdit(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("devcycle_project.test", "description", "Terraform acceptance testing-edit"),
 				),
 			},
 			{
-				Config:  testAccProjectResourceConfig,
+				Config:  testAccProjectResourceConfig(),
 				Destroy: true,
 			},
 		},
 	})
 }
 
-var testAccProjectResourceKey = "terraform-acceptance-testing" + randString
+func testAccProjectResourceKey() string {
+	return "terraform-acceptance-testing" + randString
+}
 
-var testAccProjectResourceConfig = `
+func testAccProjectResourceConfig() string {
+	return `
 resource "devcycle_project" "test" {
   name = "TerraformAccTest` + randString + `"
-  key = "` + testAccProjectResourceKey + `"
+  key = "` + testAccProjectResourceKey() + `"
   description = "Terraform acceptance testing"
 }
 `
+}
 
-var testAccProjectResourceConfigEdit = `
+func testAccProjectResourceConfigEdit() string {
+	return `
 resource "devcycle_project" "test" {
   name = "TerraformAccTest` + randString + `"
-  key = "` + testAccProjectResourceKey + `"
+  key = "` + testAccProjectResourceKey() + `"
   description = "Terraform acceptance testing-edit"
 }
 `
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -24,6 +24,7 @@ type provider struct {
 	ServerClient        *dvc_server.DVCClient
 	AccessToken         string
 	ServerClientContext context.Context
+	TerraformVersion    string
 
 	// configured is set to true at the end of the Configure method.
 	// This can be used in Resource and DataSource implementations to verify
@@ -92,6 +93,7 @@ func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 	config.AddDefaultHeader("dvc-referrer-metadata", metadata)
 	config.BasePath = "https://api.devcycle.com"
 	config.UserAgent = "terraform-provider-devcycle"
+	p.TerraformVersion = req.TerraformVersion
 	p.MgmtHTTPClient = mgmtHTTPClient
 	p.MgmtClient = dvc_mgmt.NewAPIClient(config)
 	p.ServerClient, _ = dvc_server.NewDVCClient(os.Getenv("DEVCYCLE_SERVER_TOKEN"), &dvc_server.DVCOptions{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 
 	dvc_mgmt "github.com/devcyclehq/go-mgmt-sdk"
@@ -19,6 +20,7 @@ var bucketingApiUrl = "https://bucketing-api.devcycle.com"
 // with all Resource and DataSource implementations.
 type provider struct {
 	MgmtClient          *dvc_mgmt.DVCClient
+	MgmtHTTPClient      *http.Client
 	ServerClient        *dvc_server.DVCClient
 	AccessToken         string
 	ServerClientContext context.Context
@@ -81,13 +83,16 @@ func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 		})
 	}
 
+	mgmtHTTPClient := newMgmtHTTPClient()
 	config := dvc_mgmt.NewConfiguration()
+	config.HTTPClient = mgmtHTTPClient
 	config.AddDefaultHeader("Authorization", p.AccessToken)
 	config.AddDefaultHeader("dvc-referrer", "terraform")
 	metadata := fmt.Sprintf("{\"dvc_terraform_provider_version\": \"%s\", \"terraform_version\": \"%s\"}", p.version, req.TerraformVersion)
 	config.AddDefaultHeader("dvc-referrer-metadata", metadata)
 	config.BasePath = "https://api.devcycle.com"
 	config.UserAgent = "terraform-provider-devcycle"
+	p.MgmtHTTPClient = mgmtHTTPClient
 	p.MgmtClient = dvc_mgmt.NewAPIClient(config)
 	p.ServerClient, _ = dvc_server.NewDVCClient(os.Getenv("DEVCYCLE_SERVER_TOKEN"), &dvc_server.DVCOptions{
 		EnableEdgeDB:    true,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -23,7 +23,9 @@ var randString = ""
 
 func testAccPreCheck(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	randString = randSeq(5)
+	// Longer suffix reduces collisions; must be set before building acceptance test configs
+	// (package-level config strings are evaluated after PreCheck when using config functions).
+	randString = randSeq(8)
 	t.Setenv("DEVCYCLE_CLIENT_ID", os.Getenv("DEVCYCLE_CLIENT_ID"))
 	t.Setenv("DEVCYCLE_CLIENT_SECRET", os.Getenv("DEVCYCLE_CLIENT_SECRET"))
 	t.Setenv("DEVCYCLE_ACCESS_TOKEN", os.Getenv("DEVCYCLE_ACCESS_TOKEN"))

--- a/internal/provider/variable_resource.go
+++ b/internal/provider/variable_resource.go
@@ -218,8 +218,7 @@ func (r variableResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRe
 		return
 	}
 
-	httpResponse, err := r.provider.MgmtClient.VariablesApi.VariablesControllerRemove(ctx, data.Key.Value, data.ProjectId.Value)
-	if ret := handleDevCycleHTTP(err, httpResponse, &resp.Diagnostics); ret {
+	if ret := r.provider.variablesControllerDelete(ctx, data.Key.Value, data.ProjectId.Value, &resp.Diagnostics); ret {
 		return
 	}
 

--- a/internal/provider/variable_resource_test.go
+++ b/internal/provider/variable_resource_test.go
@@ -7,34 +7,39 @@ import (
 )
 
 func TestAccVariableResource(t *testing.T) {
+	testAccPreCheck(t)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 nil,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				Config: testAccVariableResourceConfig,
+				Config: testAccVariableResourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("devcycle_variable.test", "key", testAccVariableResourceKey),
+					resource.TestCheckResourceAttr("devcycle_variable.test", "key", testAccVariableResourceKey()),
 				),
 			},
 			{
-				Config:  testAccVariableResourceConfig,
+				Config:  testAccVariableResourceConfig(),
 				Destroy: true,
 			},
 		},
 	})
 }
 
-var testAccVariableResourceKey = "terraform-acceptance-testing" + randSeq(5)
+func testAccVariableResourceKey() string {
+	return "terraform-acceptance-testing" + randString
+}
 
-var testAccVariableResourceConfig = `
+func testAccVariableResourceConfig() string {
+	return `
 resource "devcycle_variable" "test" {
-  name = "TerraformAccTest` + randSeq(5) + `"
-  key = "` + testAccVariableResourceKey + `"
+  name = "TerraformAccTest` + randString + `"
+  key = "` + testAccVariableResourceKey() + `"
   description = "Terraform acceptance testing"
   type = "Boolean"
   feature_id = "622115014b06357d06d1cf3e"
   project_id = "622112634cabe0e9fbaf974d"
 }
 `
+}

--- a/internal/provider/variables_delete.go
+++ b/internal/provider/variables_delete.go
@@ -44,7 +44,9 @@ func (p *provider) variablesControllerDelete(ctx context.Context, key, projectID
 		}
 	}
 
-	resp, err := p.doMgmtRequest(ctx, http.MethodDelete, fmt.Sprintf("/v1/projects/%s/variables/%s", projectID, key), nil, map[string]string{
+	escapedProjectID := url.PathEscape(projectID)
+	escapedKey := url.PathEscape(key)
+	resp, err := p.doMgmtRequest(ctx, http.MethodDelete, fmt.Sprintf("/v1/projects/%s/variables/%s", escapedProjectID, escapedKey), nil, map[string]string{
 		"If-Match": "*",
 	})
 	if err != nil {
@@ -59,7 +61,7 @@ func (p *provider) variablesControllerDelete(ctx context.Context, key, projectID
 		return false
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error: %s.\nHTTP Response: %v", resp.Status, resp.Request))
+		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error: %s.\nRequest URL: %s", resp.Status, responseURL(resp)))
 		return true
 	}
 
@@ -76,7 +78,10 @@ func (p *provider) waitForDetachedVariable(ctx context.Context, key, projectID s
 			_, _ = io.Copy(io.Discard, httpResp.Body)
 			_ = httpResp.Body.Close()
 		}
-		time.Sleep(time.Duration(attempt+1) * 300 * time.Millisecond)
+		if err := sleepWithContext(ctx, time.Duration(attempt+1)*300*time.Millisecond); err != nil {
+			var zero devcyclem.Variable
+			return zero, nil, err
+		}
 	}
 
 	return p.MgmtClient.VariablesApi.VariablesControllerFindOne(ctx, key, projectID)
@@ -150,7 +155,9 @@ func (p *provider) detachVariableFromFeature(ctx context.Context, variable devcy
 }
 
 func (p *provider) featureControllerDelete(ctx context.Context, key, projectID string, diags *diag.Diagnostics) bool {
-	resp, err := p.doMgmtRequest(ctx, http.MethodDelete, fmt.Sprintf("/v1/projects/%s/features/%s", projectID, key), url.Values{
+	escapedProjectID := url.PathEscape(projectID)
+	escapedKey := url.PathEscape(key)
+	resp, err := p.doMgmtRequest(ctx, http.MethodDelete, fmt.Sprintf("/v1/projects/%s/features/%s", escapedProjectID, escapedKey), url.Values{
 		"deleteVariables": {"true"},
 	}, nil)
 	if err != nil {
@@ -165,9 +172,16 @@ func (p *provider) featureControllerDelete(ctx context.Context, key, projectID s
 		return false
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error: %s.\nHTTP Response: %v", resp.Status, resp.Request))
+		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error: %s.\nRequest URL: %s", resp.Status, responseURL(resp)))
 		return true
 	}
 
 	return false
+}
+
+func responseURL(resp *http.Response) string {
+	if resp != nil && resp.Request != nil && resp.Request.URL != nil {
+		return resp.Request.URL.String()
+	}
+	return "<unknown>"
 }

--- a/internal/provider/variables_delete.go
+++ b/internal/provider/variables_delete.go
@@ -1,0 +1,86 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+const mgmtAPIBaseURL = "https://api.devcycle.com"
+
+func (p *provider) setMgmtRequestHeaders(req *http.Request) {
+	req.Header.Set("Authorization", p.AccessToken)
+	req.Header.Set("dvc-referrer", "terraform")
+	metadata := fmt.Sprintf(`{"dvc_terraform_provider_version": %q, "terraform_version": %q}`, p.version, "unknown")
+	req.Header.Set("dvc-referrer-metadata", metadata)
+	req.Header.Set("User-Agent", "terraform-provider-devcycle")
+}
+
+// variablesControllerDelete removes a variable. The Management API may require
+// If-Match with the latest ETag; the generated SDK delete method does not send it.
+func (p *provider) variablesControllerDelete(ctx context.Context, key, projectID string, diags *diag.Diagnostics) bool {
+	_, httpResp, err := p.MgmtClient.VariablesApi.VariablesControllerFindOne(ctx, key, projectID)
+	if err != nil {
+		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error reading variable before delete: %v", err))
+		return true
+	}
+
+	if httpResp.StatusCode == http.StatusNotFound {
+		return false
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode > 299 {
+		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error: variable read returned %s", httpResp.Status))
+		return true
+	}
+
+	etag := httpResp.Header.Get("ETag")
+	if etag == "" {
+		httpResp2, err := p.MgmtClient.VariablesApi.VariablesControllerRemove(ctx, key, projectID)
+		if ret := handleDevCycleHTTP(err, httpResp2, diags); ret {
+			return true
+		}
+		if httpResp2 != nil && httpResp2.Body != nil {
+			_, _ = io.Copy(io.Discard, httpResp2.Body)
+			_ = httpResp2.Body.Close()
+		}
+		return false
+	}
+
+	u := fmt.Sprintf("%s/v1/projects/%s/variables/%s",
+		mgmtAPIBaseURL,
+		url.PathEscape(projectID),
+		url.PathEscape(key),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u, nil)
+	if err != nil {
+		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error building delete request: %v", err))
+		return true
+	}
+	p.setMgmtRequestHeaders(req)
+	req.Header.Set("If-Match", etag)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error deleting variable: %v", err))
+		return true
+	}
+	if resp.Body != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return false
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error: %s.\nHTTP Response: %v", resp.Status, req))
+		return true
+	}
+
+	return false
+}

--- a/internal/provider/variables_delete.go
+++ b/internal/provider/variables_delete.go
@@ -6,65 +6,47 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
+	devcyclem "github.com/devcyclehq/go-mgmt-sdk"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
-const mgmtAPIBaseURL = "https://api.devcycle.com"
-
-func (p *provider) setMgmtRequestHeaders(req *http.Request) {
-	req.Header.Set("Authorization", p.AccessToken)
-	req.Header.Set("dvc-referrer", "terraform")
-	metadata := fmt.Sprintf(`{"dvc_terraform_provider_version": %q, "terraform_version": %q}`, p.version, "unknown")
-	req.Header.Set("dvc-referrer-metadata", metadata)
-	req.Header.Set("User-Agent", "terraform-provider-devcycle")
-}
-
-// variablesControllerDelete removes a variable. The Management API may require
-// If-Match with the latest ETag; the generated SDK delete method does not send it.
 func (p *provider) variablesControllerDelete(ctx context.Context, key, projectID string, diags *diag.Diagnostics) bool {
-	_, httpResp, err := p.MgmtClient.VariablesApi.VariablesControllerFindOne(ctx, key, projectID)
-	if err != nil {
-		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error reading variable before delete: %v", err))
-		return true
+	variable, httpResp, err := p.MgmtClient.VariablesApi.VariablesControllerFindOne(ctx, key, projectID)
+	if httpResp != nil && httpResp.Body != nil {
+		_, _ = io.Copy(io.Discard, httpResp.Body)
+		_ = httpResp.Body.Close()
 	}
-
-	if httpResp.StatusCode == http.StatusNotFound {
+	if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
 		return false
 	}
-
-	if httpResp.StatusCode < 200 || httpResp.StatusCode > 299 {
-		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error: variable read returned %s", httpResp.Status))
+	if ret := handleDevCycleHTTP(err, httpResp, diags); ret {
 		return true
 	}
 
-	etag := httpResp.Header.Get("ETag")
-	if etag == "" {
-		httpResp2, err := p.MgmtClient.VariablesApi.VariablesControllerRemove(ctx, key, projectID)
-		if ret := handleDevCycleHTTP(err, httpResp2, diags); ret {
+	if variable.Feature != "" {
+		if ret := p.detachVariableFromFeature(ctx, variable, projectID, diags); ret {
 			return true
 		}
-		if httpResp2 != nil && httpResp2.Body != nil {
-			_, _ = io.Copy(io.Discard, httpResp2.Body)
-			_ = httpResp2.Body.Close()
+
+		variable, httpResp, err = p.waitForDetachedVariable(ctx, key, projectID)
+		if httpResp != nil && httpResp.Body != nil {
+			_, _ = io.Copy(io.Discard, httpResp.Body)
+			_ = httpResp.Body.Close()
 		}
-		return false
+		if ret := handleDevCycleHTTP(err, httpResp, diags); ret {
+			return true
+		}
+		if variable.Feature != "" {
+			diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error: variable %q is still associated with feature %q after detach", key, variable.Feature))
+			return true
+		}
 	}
 
-	u := fmt.Sprintf("%s/v1/projects/%s/variables/%s",
-		mgmtAPIBaseURL,
-		url.PathEscape(projectID),
-		url.PathEscape(key),
-	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u, nil)
-	if err != nil {
-		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error building delete request: %v", err))
-		return true
-	}
-	p.setMgmtRequestHeaders(req)
-	req.Header.Set("If-Match", etag)
-
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := p.doMgmtRequest(ctx, http.MethodDelete, fmt.Sprintf("/v1/projects/%s/variables/%s", projectID, key), nil, map[string]string{
+		"If-Match": "*",
+	})
 	if err != nil {
 		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error deleting variable: %v", err))
 		return true
@@ -73,12 +55,117 @@ func (p *provider) variablesControllerDelete(ctx context.Context, key, projectID
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}
-
 	if resp.StatusCode == http.StatusNotFound {
 		return false
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error: %s.\nHTTP Response: %v", resp.Status, req))
+		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error: %s.\nHTTP Response: %v", resp.Status, resp.Request))
+		return true
+	}
+
+	return false
+}
+
+func (p *provider) waitForDetachedVariable(ctx context.Context, key, projectID string) (devcyclem.Variable, *http.Response, error) {
+	for attempt := 0; attempt < 5; attempt++ {
+		variable, httpResp, err := p.MgmtClient.VariablesApi.VariablesControllerFindOne(ctx, key, projectID)
+		if err != nil || httpResp == nil || httpResp.StatusCode == http.StatusNotFound || variable.Feature == "" {
+			return variable, httpResp, err
+		}
+		if httpResp.Body != nil {
+			_, _ = io.Copy(io.Discard, httpResp.Body)
+			_ = httpResp.Body.Close()
+		}
+		time.Sleep(time.Duration(attempt+1) * 300 * time.Millisecond)
+	}
+
+	return p.MgmtClient.VariablesApi.VariablesControllerFindOne(ctx, key, projectID)
+}
+
+func (p *provider) detachVariableFromFeature(ctx context.Context, variable devcyclem.Variable, projectID string, diags *diag.Diagnostics) bool {
+	feature, httpResp, err := p.MgmtClient.FeaturesApi.FeaturesControllerFindOne(ctx, variable.Feature, projectID)
+	if httpResp != nil && httpResp.Body != nil {
+		_, _ = io.Copy(io.Discard, httpResp.Body)
+		_ = httpResp.Body.Close()
+	}
+	if ret := handleDevCycleHTTP(err, httpResp, diags); ret {
+		return true
+	}
+
+	update := devcyclem.UpdateFeatureDto{
+		Name:        feature.Name,
+		Key:         feature.Key,
+		Description: feature.Description,
+		Type_:       feature.Type_,
+		Tags:        feature.Tags,
+	}
+
+	removed := false
+	for _, existingVariable := range feature.Variables {
+		if existingVariable.Key == variable.Key {
+			removed = true
+			continue
+		}
+
+		update.Variables = append(update.Variables, devcyclem.CreateVariableDto{
+			Name:         existingVariable.Name,
+			Description:  existingVariable.Description,
+			Key:          existingVariable.Key,
+			Feature:      feature.Key,
+			Type_:        existingVariable.Type_,
+			DefaultValue: existingVariable.DefaultValue,
+		})
+	}
+
+	if !removed {
+		return false
+	}
+
+	for _, variation := range feature.Variations {
+		nextVariables := make(map[string]interface{}, len(variation.Variables))
+		for variationKey, variationValue := range variation.Variables {
+			if variationKey == variable.Key {
+				continue
+			}
+			nextVariables[variationKey] = variationValue
+		}
+
+		update.Variations = append(update.Variations, devcyclem.FeatureVariationDto{
+			Key:       variation.Key,
+			Name:      variation.Name,
+			Variables: nextVariables,
+		})
+	}
+
+	_, httpResp, err = p.MgmtClient.FeaturesApi.FeaturesControllerUpdate(ctx, update, feature.Key, projectID)
+	if httpResp != nil && httpResp.Body != nil {
+		_, _ = io.Copy(io.Discard, httpResp.Body)
+		_ = httpResp.Body.Close()
+	}
+	if ret := handleDevCycleHTTP(err, httpResp, diags); ret {
+		return true
+	}
+
+	return false
+}
+
+func (p *provider) featureControllerDelete(ctx context.Context, key, projectID string, diags *diag.Diagnostics) bool {
+	resp, err := p.doMgmtRequest(ctx, http.MethodDelete, fmt.Sprintf("/v1/projects/%s/features/%s", projectID, key), url.Values{
+		"deleteVariables": {"true"},
+	}, nil)
+	if err != nil {
+		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error deleting feature: %v", err))
+		return true
+	}
+	if resp.Body != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return false
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		diags.AddError("Client Error", fmt.Sprintf("DevCycle Terraform Error: %s.\nHTTP Response: %v", resp.Status, resp.Request))
 		return true
 	}
 


### PR DESCRIPTION
## Summary

- update CI workflows to use Go 1.24.1 so they match `go.mod` / `toolchain`
- fix acceptance test config generation so random resource suffixes are applied before configs are built
- align feature / variable destroy flows with current DevCycle Management API behavior, including retrying transient 502/503/504 responses on idempotent management calls

## Notes

- this is the base PR for the stacked grpc security bump in #202
- `go test ./...` passes locally